### PR TITLE
fix(LT-4299): remove monitoring self-registration

### DIFF
--- a/src/Lykke.Job.CandlesHistoryWriter/Lykke.Job.CandlesHistoryWriter.csproj
+++ b/src/Lykke.Job.CandlesHistoryWriter/Lykke.Job.CandlesHistoryWriter.csproj
@@ -34,7 +34,6 @@
     <PackageReference Include="Lykke.Common.ApiLibrary" Version="3.1.1" />
     <PackageReference Include="Lykke.MarginTrading.BookKeeper.Contracts" Version="1.5.2" />
     <PackageReference Include="Lykke.MarginTrading.SettingsService.Contracts" Version="1.5.0" />
-    <PackageReference Include="Lykke.MonitoringServiceApiCaller" Version="1.8.0" />
     <PackageReference Include="Lykke.Service.Assets.Client" Version="4.7.0" />
     <PackageReference Include="Lykke.Snow.Common.Startup" Version="3.0.1" />
     <PackageReference Include="LykkeBiz.Common" Version="8.1.0" />

--- a/src/Lykke.Job.CandlesHistoryWriter/Startup.cs
+++ b/src/Lykke.Job.CandlesHistoryWriter/Startup.cs
@@ -27,7 +27,6 @@ using Lykke.Job.CandlesHistoryWriter.Models;
 using Lykke.Job.CandlesHistoryWriter.Services.Settings;
 using AzureQueueSettings = Lykke.AzureQueueIntegration.AzureQueueSettings;
 using Lykke.Job.CandlesHistoryWriter.Core.Domain.Candles;
-using Lykke.MonitoringServiceApiCaller;
 using Lykke.Logs.MsSql;
 using Lykke.Logs.MsSql.Repositories;
 using Lykke.Logs.Serilog;
@@ -37,7 +36,6 @@ using Microsoft.Extensions.Logging;
 using Lykke.Snow.Common.Startup.Log;
 using Lykke.Snow.Common.Startup.Hosting;
 using MarginTrading.SettingsService.Contracts;
-using MarginTrading.SettingsService.Contracts.Candles;
 using Microsoft.Extensions.Hosting;
 using Microsoft.OpenApi.Models;
 
@@ -221,20 +219,9 @@ namespace Lykke.Job.CandlesHistoryWriter
             {
                 await ApplicationContainer.Resolve<IStartupManager>().StartAsync();
 
-                var monitoringServiceClientSettings =
-                    ApplicationContainer.ResolveOptional<MonitoringServiceClientSettings>();
-
                 Program.AppHost.WriteLogs(Environment, Log);
 
-                if (monitoringServiceClientSettings != null &&
-                    !string.IsNullOrEmpty(monitoringServiceClientSettings.MonitoringServiceUrl))
-                {
-                    await AutoRegistrationInMonitoring.RegisterAsync(Configuration,
-                        monitoringServiceClientSettings.MonitoringServiceUrl,
-                    Log);
-
-                    await Log.WriteMonitorAsync("", "", "Started");
-                }
+                await Log.WriteMonitorAsync(nameof(Startup), nameof(StartApplication), "", "Started");
 
             }
             catch (Exception ex)


### PR DESCRIPTION
MonitoringServiceApiClient package removal also removes transitive dependency on old package Lykke.HttpClientGenerator 2.2.0 which was built using Polly v6. 