### PR TITLE
Lt 5672  candleshistorywriter redis timeout

### DIFF
--- a/Lykke.Job.CandlesHistoryWriter.sln.DotSettings
+++ b/Lykke.Job.CandlesHistoryWriter.sln.DotSettings
@@ -1,4 +1,5 @@
 ﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EFeature_002EServices_002ECodeCleanup_002EFileHeader_002EFileHeaderSettingsMigrate/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Autofac/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Cqrs/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Lykke/@EntryIndexedValue">True</s:Boolean>

--- a/src/Lykke.Job.CandlesHistoryWriter.Services/Candles/RedisCacheTruncator.cs
+++ b/src/Lykke.Job.CandlesHistoryWriter.Services/Candles/RedisCacheTruncator.cs
@@ -28,7 +28,7 @@ namespace Lykke.Job.CandlesHistoryWriter.Services.Candles
             MarketType market,
             TimeSpan cacheCleanupPeriod,
             ICandlesAmountManager candlesAmountManager,
-            ILog log, 
+            ILog log,
             ICandlesShardValidator candlesShardValidator,
             IConnectionMultiplexer redis)
             : base(nameof(RedisCacheTruncator), (int)cacheCleanupPeriod.TotalMilliseconds, log)
@@ -56,8 +56,8 @@ namespace Lykke.Job.CandlesHistoryWriter.Services.Candles
                         var key = RedisCandlesCacheService.GetKey(_market, assetId, priceType, timeInterval);
 
                         var candlesAmountToStore = _candlesAmountManager.GetCandlesAmountToStore(timeInterval);
-                        
-                        db.SortedSetRemoveRangeByRank(key, 0, -candlesAmountToStore - 1, CommandFlags.FireAndForget);
+
+                        await db.SortedSetRemoveRangeByRankAsync(key, 0, -candlesAmountToStore - 1, CommandFlags.FireAndForget);
                     }
                 }
             }

--- a/src/Lykke.Job.CandlesHistoryWriter.Services/Lykke.Job.CandlesHistoryWriter.Services.csproj
+++ b/src/Lykke.Job.CandlesHistoryWriter.Services/Lykke.Job.CandlesHistoryWriter.Services.csproj
@@ -14,15 +14,13 @@
     <PackageReference Include="LykkeBiz.Snow.Cqrs" Version="1.2.0" />
     <PackageReference Include="morelinq" Version="3.3.2" />
     <PackageReference Include="Polly" Version="7.2.3" />
-    <PackageReference Include="StackExchange.Redis" Version="2.6.66" />
+    <PackageReference Include="StackExchange.Redis" Version="2.8.0" />
     <PackageReference Include="System.Runtime.Extensions" Version="4.3.1" />
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference
-      Include="..\Lykke.Job.CandleHistoryWriter.Repositories\Lykke.Job.CandleHistoryWriter.Repositories.csproj" />
-    <ProjectReference
-      Include="..\Lykke.Job.CandlesHistoryWriter.Core\Lykke.Job.CandlesHistoryWriter.Core.csproj" />
+    <ProjectReference Include="..\Lykke.Job.CandleHistoryWriter.Repositories\Lykke.Job.CandleHistoryWriter.Repositories.csproj" />
+    <ProjectReference Include="..\Lykke.Job.CandlesHistoryWriter.Core\Lykke.Job.CandlesHistoryWriter.Core.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/Lykke.Job.CandlesHistoryWriter.Services/Settings/CandlesHistoryWriterSettings.cs
+++ b/src/Lykke.Job.CandlesHistoryWriter.Services/Settings/CandlesHistoryWriterSettings.cs
@@ -10,17 +10,17 @@ namespace Lykke.Job.CandlesHistoryWriter.Services.Settings
 {
     [UsedImplicitly]
     public class CandlesHistoryWriterSettings
-    {        
+    {
         public AssetsCacheSettings AssetsCache { get; set; }
-        
+
         public RabbitSettings Rabbit { get; set; }
-        
+
         public QueueMonitorSettings QueueMonitor { get; set; }
-        
+
         public PersistenceSettings Persistence { get; set; }
-        
+
         public DbSettings Db { get; set; }
-      
+
         [Optional, CanBeNull]
         public MigrationSettings Migration { get; set; }
 
@@ -30,14 +30,20 @@ namespace Lykke.Job.CandlesHistoryWriter.Services.Settings
         public ResourceMonitorSettings ResourceMonitor { get; set; }
 
         public int HistoryTicksCacheSize { get; set; }
-        
+
         public TimeSpan CacheCleanupPeriod { get; set; }
-        
+
+        /// <summary>
+        /// The size of the asset pairs batch when caching candles
+        /// </summary>
+        [Optional]
+        public int? CacheCandlesAssetsBatchSize { get; set; }
+
         [Optional]
         public bool UseSerilog { get; set; }
 
         public CqrsSettings Cqrs { get; set; }
-        
+
         [Optional]
         public CleanupSettings CleanupSettings { get; set; } = new CleanupSettings();
     }

--- a/src/Lykke.Job.CandlesHistoryWriter/DependencyInjection/JobModule.cs
+++ b/src/Lykke.Job.CandlesHistoryWriter/DependencyInjection/JobModule.cs
@@ -171,7 +171,7 @@ namespace Lykke.Job.CandlesHistoryWriter.DependencyInjection
             builder.RegisterInstance(_candlesShardRemoteSettings)
                 .AsSelf()
                 .SingleInstance();
-            
+
             builder.RegisterType<HealthService>()
                 .As<IHealthService>()
                 .SingleInstance();
@@ -283,11 +283,10 @@ namespace Lykke.Job.CandlesHistoryWriter.DependencyInjection
             RegisterCandlesCleanup(builder);
 
             builder.RegisterType<RedisCacheTruncator>()
-                .As<IStartable>()
+                .AsSelf()
                 .SingleInstance()
                 .WithParameter(TypedParameter.From(_marketType))
-                .WithParameter(TypedParameter.From(_settings.CacheCleanupPeriod))
-                .AutoActivate();
+                .WithParameter(TypedParameter.From(_settings.CacheCleanupPeriod));
 
             builder.RegisterType<CandlesShardValidator>()
                 .As<ICandlesShardValidator>()

--- a/src/Lykke.Job.CandlesHistoryWriter/DependencyInjection/JobModule.cs
+++ b/src/Lykke.Job.CandlesHistoryWriter/DependencyInjection/JobModule.cs
@@ -278,7 +278,9 @@ namespace Lykke.Job.CandlesHistoryWriter.DependencyInjection
                 .AutoActivate();
 
             builder.RegisterType<CandlesCacheInitalizationService>()
-                .As<ICandlesCacheInitalizationService>();
+                .As<ICandlesCacheInitalizationService>()
+                .WithParameter(TypedParameter.From(_settings.CacheCandlesAssetsBatchSize))
+                .SingleInstance();
 
             RegisterCandlesCleanup(builder);
 

--- a/tests/Lykke.Job.CandlesHistoryWriter.Tests/CandlesCacheInitializationTest.cs
+++ b/tests/Lykke.Job.CandlesHistoryWriter.Tests/CandlesCacheInitializationTest.cs
@@ -83,7 +83,8 @@ namespace Lykke.Job.CandlesHistoryWriter.Tests
                 _cacheServiceMock.Object,
                 _historyRepositoryMock.Object,
                 _candlesAmountManagerMock.Object,
-                _candlesShardValidator.Object);
+                _candlesShardValidator.Object,
+                null);
         }
 
         [TestMethod]
@@ -95,12 +96,12 @@ namespace Lykke.Job.CandlesHistoryWriter.Tests
             _dateTimeProviderMock.SetupGet(p => p.UtcNow).Returns(now);
             _historyRepositoryMock
                 .Setup(r => r.GetLastCandlesAsync(
-                    It.IsAny<string>(), 
-                    It.IsAny<CandleTimeInterval>(), 
-                    It.IsAny<CandlePriceType>(), 
-                    It.IsAny<DateTime>(), 
+                    It.IsAny<string>(),
+                    It.IsAny<CandleTimeInterval>(),
+                    It.IsAny<CandlePriceType>(),
+                    It.IsAny<DateTime>(),
                     It.IsAny<int>()))
-                .ReturnsAsync((string a, CandleTimeInterval i, CandlePriceType p, DateTime t, int n) => 
+                .ReturnsAsync((string a, CandleTimeInterval i, CandlePriceType p, DateTime t, int n) =>
                     new[]
                     {
                         new TestCandle(),


### PR DESCRIPTION
This update introduces Redis client library update to the latest one as well as splitting the following processes: caching candles at startup and running candles cache truncator periodically. Before these processes might run in parallel which could cause performance issues.

Also there is new configuration key `CacheCandlesAssetsBatchSize` added. It controls the size of the asset pairs batch when caching candles which affects startup performance. For better performace it is recommended to use values > 10. This will allow the utilize client host resources and use Redis connection more optimal. However, the particular value is a matter of experiments on particular environment setup.